### PR TITLE
Add Perl port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Note: Some ports are experimental. The most battle-tested code is in the [Cosmop
 - [luajit](https://github.com/ahgamut/LuaJIT-cosmo) - Port of Lua JIT
 - [make](https://github.com/ahgamut/gnu-make-cosmopolitan) - Port of GNU Make
 - [nim](https://github.com/gnu-enjoyer/ActuallyPortableNim) - Turns Nim into a build once run anywhere language
+- [perl](https://github.com/G4Vi/perl5/tree/cosmo) - Port of Perl
 - [php73](https://github.com/ahgamut/php-src/tree/cosmo_php73) - Port of  PHP 7.3
 - [rust ape example](https://github.com/ahgamut/rust-ape-example) - Rust APE Example
 - [scalajs ape example](https://github.com/lolgab/cosmopolitan-scalajs-example) - Scala.js APE Example


### PR DESCRIPTION
The Perl port is still very experimental, but I figured it should be added to the list to avoid accidental duplicate work.