### PR TITLE
Add mruby support link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Note: Some ports are experimental. The most battle-tested code is in the [Cosmop
 - [lua](https://github.com/ahgamut/lua/tree/cosmopolitan) - Port of Lua
 - [luajit](https://github.com/ahgamut/LuaJIT-cosmo) - Port of Lua JIT
 - [make](https://github.com/ahgamut/gnu-make-cosmopolitan) - Port of GNU Make
+- [mruby](https://github.com/mruby/mruby) - mruby [supports cosmo](https://github.com/mruby/mruby/pull/6681) as a build target
 - [nim](https://github.com/gnu-enjoyer/ActuallyPortableNim) - Turns Nim into a build once run anywhere language
 - [perl](https://computoid.com/APPerl/) - Port of Perl
 - [php73](https://github.com/ahgamut/php-src/tree/cosmo_php73) - Port of PHP 7.3


### PR DESCRIPTION
I've added cosmo to mruby as a compilation target. It allows building portable mruby applications, although you need to specify the dependencies upfront and be prepared to resolve any issues with gems using native extensions.